### PR TITLE
Bugfix for useUpdateTrade hook

### DIFF
--- a/src/hooks/mutations/useUpdateTrade.tsx
+++ b/src/hooks/mutations/useUpdateTrade.tsx
@@ -35,8 +35,11 @@ export function useUpdateTrade() {
 
       return api.put(`trades/${portfolioId}/${tradeId}`, payload);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["portfolio-trades"] });
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["trades", variables.portfolioId] });
+      queryClient.invalidateQueries({ queryKey: ["trades"] });
+      
+      queryClient.refetchQueries({ queryKey: ["trades", variables.portfolioId] });
     },
   });
 }


### PR DESCRIPTION
# Summary
- This pull request addresses an issue in the useUpdateTrade hook where queries were not being invalidated correctly after a trade update. This fix ensures that the relevant queries are invalidated, keeping the data in sync.

# Changes Included:
- Updated the useUpdateTrade hook to properly invalidate queries related to portfolio trades.
Ensured that the `queryClient.invalidateQueries` method is called with the correct query keys.